### PR TITLE
Add `cell-autofill-hit-area-size` token

### DIFF
--- a/tokensKeys.js
+++ b/tokensKeys.js
@@ -72,6 +72,7 @@ const tokensKeys = [
 
     // Cell Autofill Variables
     "cell-autofill-size",
+    "cell-autofill-hit-area-size",
     "cell-autofill-border-width",
     "cell-autofill-border-radius",
     "cell-autofill-border-color",


### PR DESCRIPTION
The PR adds a new token to the list. The change is related to https://github.com/handsontable/handsontable/pull/11952.