### PR TITLE
Add notification variables

### DIFF
--- a/tokensKeys.js
+++ b/tokensKeys.js
@@ -376,6 +376,14 @@ const tokensKeys = [
   "dialog-content-border-radius",
   "dialog-content-background-color",
 
+  // Notification Variables (toast chrome and variant accent bars; info variant has no accent)
+  "notification-foreground-color",
+  "notification-background-color",
+  "notification-border-color",
+  "notification-success-accent",
+  "notification-warning-accent",
+  "notification-error-accent",
+
   // MultiSelect Editor And Renderer Variables
   "chip-background",
   "chip-border-radius",

--- a/utils/helpers/iconsMap.js
+++ b/utils/helpers/iconsMap.js
@@ -121,6 +121,10 @@ ${prefix}.ht-multi-select-chip-remove::before {
   ${icon(icons, "chipClose")}
 }
 
+${prefix}.ht-notification__close::before {
+  ${icon(icons, "chipClose")}
+}
+
 ${prefix}.ht-multi-select-editor-search-icon {
   ${icon(icons, "search")}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new theme token keys and a CSS selector mapping for the notification close icon without changing existing behavior or logic.
> 
> **Overview**
> Adds a new set of theme token keys for notification/toast styling (foreground/background/border plus success/warning/error accent colors).
> 
> Updates `iconsMap` to render a close icon for notifications by mapping `.ht-notification__close::before` to the existing `chipClose` asset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc5fe7546c774d619db460ec66d9811945afa31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->