### PR TITLE
Update README to reflect repository archiving and migration of theme generator to handsontable monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Figma UI kit for Handsontable
 
+> **This repository is archived.** The theme generator has moved into the [handsontable](https://github.com/handsontable/handsontable) monorepo at [`handsontable/scripts/themes/figma`](https://github.com/handsontable/handsontable/tree/develop/handsontable/scripts/themes/figma).
+
 A tool for generating theme files from Figma design tokens.
 
 ## How to use
 
-This tool helps you generate Handsontable theme files from Figma design tokens.
+Use the generator in the monorepo — see its [README](https://github.com/handsontable/handsontable/tree/develop/handsontable/scripts/themes/figma#readme) for full instructions.
 
 ### Prerequisites
 
-- Node.js version 20 or higher
+- Node.js 22 (see the monorepo `.nvmrc`)
 - Access to Figma with design tokens
 
 ### Steps
@@ -30,18 +32,18 @@ This tool helps you generate Handsontable theme files from Figma design tokens.
 
 2. Set up the theme generator:
 
-    - Clone this repository
-    - Run `npm install`
-    - Place the exported `tokens.json` file in the root directory
+    - Clone the [handsontable](https://github.com/handsontable/handsontable) repository
+    - Place the exported `tokens.json` file at `handsontable/scripts/themes/figma/tokens.json` (gitignored)
 
 3. Generate theme files:
 
-    - Run `npm start` to generate the theme files
-    - The generated files will appear in the `/output` directory
+    - From the `handsontable/` package root, run `npm run generate:themes`
+    - The generated files are written to `handsontable/src/themes/static/`
+    - Review and commit the regenerated files under `src/themes/static/`
 
 ## Output Structure
 
-The tool generates the following files in the `/output` directory:
+The generator writes the following files to `handsontable/src/themes/static/`:
 
 ### CSS Files
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Figma UI kit for Handsontable
 
-> **This repository is archived.** The theme generator has moved into the [handsontable](https://github.com/handsontable/handsontable) monorepo at [`handsontable/scripts/themes/figma`](https://github.com/handsontable/handsontable/tree/develop/handsontable/scripts/themes/figma).
+> **This repository is archived.** The theme generator has moved into the [handsontable](https://github.com/handsontable/handsontable) monorepo at [`handsontable/scripts/themes/figma`](https://github.com/handsontable/handsontable/tree/develop/handsontable/scripts/themes/figma). Starting with **Handsontable 18.0.0**, the generated themes live in that repo and are consumed via the Theme API or CSS class names.
 
 A tool for generating theme files from Figma design tokens.
 
@@ -69,6 +69,8 @@ Theme variants supported: `.ht-theme-[name]` (light), `.ht-theme-[name]-dark`, `
 - `variables/helpers/iconsMap.js` - Helper for generating icon CSS
 
 ## Usage
+
+Available from **Handsontable 18.0.0** onward.
 
 ### Option 1: JavaScript (Theme API)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or build behavior in this repository.
> 
> **Overview**
> Adds a prominent **archived** notice and redirects contributors to the theme generator at `handsontable/scripts/themes/figma` in the main monorepo, noting that generated themes ship from **Handsontable 18.0.0** via the Theme API or CSS classes.
> 
> **How to use** is rewritten for the monorepo workflow: prerequisites now call for **Node.js 22**, `tokens.json` goes under `handsontable/scripts/themes/figma/`, generation uses **`npm run generate:themes`** from the `handsontable/` package root, and outputs are described under **`handsontable/src/themes/static/`** (with a note to commit regenerated static files). The usage section adds the **18.0.0** availability requirement; import paths in examples already match the monorepo layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1556c9f6278b3dc05a734f06be8fcc8265879c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->